### PR TITLE
Display additional error information if deploy fails

### DIFF
--- a/lib/fastlane/plugin/airwatch_workspaceone/actions/deploy_build_action.rb
+++ b/lib/fastlane/plugin/airwatch_workspaceone/actions/deploy_build_action.rb
@@ -181,7 +181,14 @@ module Fastlane
           UI.message(body.to_json)
         end
 
-        response = RestClient.post($host_url + BEGIN_INSTALL_SUFFIX, body.to_json, {content_type: :json, accept: :json, 'aw-tenant-code': $aw_tenant_code, 'Authorization': "Basic " + $b64_encoded_auth})
+        begin
+          response = RestClient.post($host_url + BEGIN_INSTALL_SUFFIX, body.to_json, {content_type: :json, accept: :json, 'aw-tenant-code': $aw_tenant_code, 'Authorization': "Basic " + $b64_encoded_auth})
+        rescue RestClient::ExceptionWithResponse => e
+          UI.message("ERROR! Response code: %d" % [e.response.code])
+          UI.message("Response body:")
+          UI.message(e.response.body)
+          raise
+        end
 
         if debug
           UI.message("Response code: %d" % [response.code])


### PR DESCRIPTION
Airwatch can reject a deploy for a variety of reasons. (In our case, it's often because we forgot to update the version number and it wants a new one.) If we do not surface the error message, however, we have no way to tell why it has failed. This adds some minimal error handling on the network call so that we can see the message the server sends back if a deploy fails.